### PR TITLE
Add network accept function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,27 @@ The API is very similar to that of [ocaml-uring](https://github.com/ocaml-multic
 
 To read a file, you first create a completion port, then open the file using the `Iocp.Handle` module. This ensures the file handle has `FILE_FLAG_OVERLAPPED` set. You can then perform the asynchronous read and wait on the completion port to return the result to you. By default, the completion status will wait indefinitely for a completion packet to arrive.
 
-<!-- TODO: Mdx doesn't really work on cygwin :/ -->
+This program copies a file.
+
+<!-- $MDX file=test/copy.ml -->
+```ocaml
+type req = [ `R | `W ]
+
+let () =
+  let iocp = Iocp.create () in
+  let fd = Iocp.Handle.openfile Sys.argv.(1) [O_RDONLY] 0 in
+  let out = Iocp.Handle.openfile Sys.argv.(2) [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
+  let buf = Cstruct.create 1024 in
+  let _job = Iocp.read_file iocp fd buf 1024 `R (Iocp.Overlapped.create ()) in
+  match Iocp.get_queued_completion_status iocp with
+    | None -> assert false
+    | Some t ->
+      assert (t.data = `R);
+      let _job = Iocp.write_file iocp out buf t.bytes_transferred `W (Iocp.Overlapped.create ()) in
+      match Iocp.get_queued_completion_status iocp with
+      | None -> assert false
+      | Some t ->
+        assert (t.data = `W);
+        Unix.close (fd :> Unix.file_descr);
+        Unix.close (out :> Unix.file_descr)
+```

--- a/src/iocp.ml
+++ b/src/iocp.ml
@@ -9,10 +9,33 @@ module Overlapped = struct
   external create : unit -> t = "ocaml_iocp_make_overlapped"
 end
 
+module Sockaddr = Sockaddr
+
 module Handle = struct
   type t = Unix.file_descr
   let to_unix t = t
   external openfile : string -> Unix.open_flag list -> Unix.file_perm -> t = "ocaml_iocp_unix_open"
+
+  let of_unix t = t
+end
+
+(* AcceptEx only puts data (like the remote address) in a special buffer that needs to
+   be parsed by [GetAcceptExSockaddrs]. We don't care about the first message received 
+   so we don't need that much space in the buffer. *)
+module Accept_buffer = struct
+  type t = Cstruct.t
+  
+  external get_remote : Cstruct.buffer -> Handle.t -> Sockaddr.t -> unit = "ocaml_iocp_get_accept_ex_sockaddr"
+
+  let get_remote t h =
+    let s = Sockaddr.create () in
+    get_remote (Cstruct.to_bigarray t) h s;
+    s
+
+  let create () =
+    (* TODO: get sizeof(sock_addr_union) to work the size out properly *)
+    let buf = Cstruct.create 128 in
+    buf
 end
 
 (* Bindings to C API *)
@@ -36,6 +59,7 @@ module Iocp = struct
   (* Operations *)
   external read_file : t -> Handle.t -> id -> Cstruct.buffer -> int -> Overlapped.t -> bool = "ocaml_iocp_read_file_bytes" "ocaml_iocp_read_file"
   external write_file : t -> Handle.t -> id -> Cstruct.buffer -> int -> Overlapped.t -> bool = "ocaml_iocp_write_file_bytes" "ocaml_iocp_write_file"
+  external accept : t -> Handle.t -> Handle.t -> id -> Cstruct.buffer -> Overlapped.t -> bool = "ocaml_iocp_accept_bytes" "ocaml_iocp_accept"
 end
 
 type 'a t = { 
@@ -76,13 +100,17 @@ let with_id_full : type a. a t -> (Heap.ptr -> bool) -> a -> extra_data:'b -> a 
         None
       )
   
-let with_id t fn a = with_id_full t fn a ~extra_data:()
+(* let with_id t fn a = with_id_full t fn a ~extra_data:() *)
 
 let read_file t fd buf num_bytes data ol =
-  with_id t (fun id -> Iocp.read_file t.iocp fd id (Cstruct.to_bigarray buf) num_bytes ol) data
+  with_id_full t (fun id -> Iocp.read_file t.iocp fd id (Cstruct.to_bigarray buf) num_bytes ol) data ~extra_data:buf
 
 let write_file t fd buf num_bytes data ol =
-  with_id t (fun id -> Iocp.write_file t.iocp fd id (Cstruct.to_bigarray buf) num_bytes ol) data
+  with_id_full t (fun id -> Iocp.write_file t.iocp fd id (Cstruct.to_bigarray buf) num_bytes ol) data ~extra_data:buf
+
+let accept t fd acc buf data ol =
+  let accept_buffer = Cstruct.to_bigarray buf in
+  with_id_full t (fun id -> Iocp.accept t.iocp fd acc id accept_buffer ol) data ~extra_data:accept_buffer
 
 (*---------------------------------------------------------------------------
   Copyright (c) 2022 <patrick@sirref.org>

--- a/src/iocp.mli
+++ b/src/iocp.mli
@@ -1,4 +1,7 @@
-(* {1 Input/Output Completion Ports}*)
+(** {2 Input/Ouput Completion Ports} 
+    
+    Bindings to input/output completion ports (IOCP) allowing for efficient,
+    asynchronous IO on Windows. *)
 
 module Overlapped : sig
   type t
@@ -20,18 +23,19 @@ module Handle : sig
     val to_unix : t -> Unix.file_descr
     (** Converts a handle to a unix file-descriptor. Note you can also do type coercion too,
         such as [(fd :> Unix.file_descr)]. *)
+
+    val of_unix : Unix.file_descr -> t
+    (** Potentially dangerous -- this function exists to allow other async-ready file descriptors 
+        to be coerced to the right type. Converting an actual file that was not opened with [FILE_FLAG_OVERLAPPED]
+        will result in errors, use {! openfile} for that instead. *)
 end
 
-(** {2 Input/Ouput Completion Ports} 
-    
-    Bindings to input/output completion ports (IOCP) allowing for efficient,
-    asynchronous IO on Windows.*)
-
 type 'a t
+(** A completion port that passes key data of type ['a]. *)
 
 type 'a job
-
-val create : ?threads:int -> unit -> 'a t
+(** A handle to an in-flight asynchronous job, this can be used to cancel the job
+    in some cases. *)
 
 val create_with_fd : ?threads:int -> Handle.t -> 'a -> 'a t
 (** [create ?threads fd data] makes a new IOCP for the handle [fd], associating
@@ -44,11 +48,41 @@ val create_with_fd : ?threads:int -> Handle.t -> 'a -> 'a t
            then [0] is passed which allows as many threads as there are processors in the 
            system. *)
 
+val create : ?threads:int -> unit -> 'a t
+(** Like {! create_with_fd} except no handle is associated with the completion port. *)
+
 type 'a completion_status = { data : 'a; bytes_transferred : int }
+(** A completion status  *)
 
 val get_queued_completion_status : 'a t  -> 'a completion_status option
+(** [get_queued_completion_status t] will wait indefinitely for a completion packet to arrive 
+    at the completion port [t]. *)
 
 (** {2 File Operations} *)
 
 val read_file : 'a t -> Handle.t -> Cstruct.t -> int -> 'a -> Overlapped.t -> 'a job option
 val write_file : 'a t -> Handle.t -> Cstruct.t -> int -> 'a -> Overlapped.t -> 'a job option
+
+(** {2 Networking} *)
+module Sockaddr = Sockaddr
+
+(** An accept buffer is used to store information from a connection upon being accepted *)
+module Accept_buffer : sig
+  type t
+  (** An accept buffer *)
+  
+  val create : unit -> t
+  (** Create a fresh new buffer to be used with an {! accept} request. *)
+  
+  val get_remote : t -> Handle.t -> Sockaddr.t
+  (** [get_remote t fd] returns the remote socket address of a connection. The handle 
+      should be the listening socket in the connection. *)
+end
+
+val accept : 'a t -> Handle.t -> Handle.t -> Accept_buffer.t -> 'a -> Overlapped.t -> 'a job option
+(** [accept t listen accept buf data o] accepts connection on the socket [accept] coming into the
+    address [listen] is listening too and pushes completion packets to [t]. The accept buffer [buf]
+    will be updated to contain the remote address of the incoming connection. 
+    
+    For more information, {{: https://docs.microsoft.com/en-us/windows/win32/api/mswsock/nf-mswsock-acceptex#parameters}
+    the Microsoft documentation explains the parameters}.*)

--- a/src/sockaddr.ml
+++ b/src/sockaddr.ml
@@ -1,0 +1,24 @@
+(*
+ * Copyright (C) 2020-2021 Anil Madhavapeddy
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type t
+
+external of_unix : Unix.sockaddr -> t = "ocaml_iocp_make_sockaddr"
+external get : t -> Unix.sockaddr = "ocaml_iocp_extract_sockaddr"
+
+let dummy_addr = Unix.ADDR_UNIX "-"
+
+let create () = of_unix dummy_addr

--- a/src/sockaddr.mli
+++ b/src/sockaddr.mli
@@ -1,0 +1,23 @@
+(*
+ * Copyright (C) 2020-2021 Anil Madhavapeddy
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* Borrowed from the IO_URING bindings *)
+
+(** Holder for the peer's address in {!accept}. *)
+type t
+
+val create : unit -> t
+val get : t -> Unix.sockaddr

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+## Tests and Examples
+
+### Copy
+
+The `copy.ml` file contains a very simple program that copies one file to another. This is run as a test to make sure that `./copy.exe test.md test.out` produces an identical file.
+
+### Net
+
+Net starts a TCP socket listening on `127.0.0.1:8080` for an incoming connection. Once connected, it then reads a single bit of data sent over the connection. With `./net.exe` running in one terminal you can use `nc 127.0.0.1 8080` to test it.

--- a/test/copy.ml
+++ b/test/copy.ml
@@ -3,17 +3,17 @@ type req = [ `R | `W ]
 let () =
   let iocp = Iocp.create () in
   let fd = Iocp.Handle.openfile Sys.argv.(1) [O_RDONLY] 0 in
-  let out = Iocp.Handle.openfile Sys.argv.(2) [O_WRONLY; O_CREAT; O_TRUNC] 0o777 in
+  let out = Iocp.Handle.openfile Sys.argv.(2) [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
   let buf = Cstruct.create 1024 in
   let _job = Iocp.read_file iocp fd buf 1024 `R (Iocp.Overlapped.create ()) in
   match Iocp.get_queued_completion_status iocp with
     | None -> assert false
-    | Some t -> 
+    | Some t ->
       assert (t.data = `R);
       let _job = Iocp.write_file iocp out buf t.bytes_transferred `W (Iocp.Overlapped.create ()) in
       match Iocp.get_queued_completion_status iocp with
       | None -> assert false
-      | Some t -> 
+      | Some t ->
         assert (t.data = `W);
         Unix.close (fd :> Unix.file_descr);
         Unix.close (out :> Unix.file_descr)

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
-(executable
- (name copy)
+(executables
+ (names copy net)
  (libraries iocp))
 
 (rule

--- a/test/net.ml
+++ b/test/net.ml
@@ -1,0 +1,38 @@
+(* TCP Network connections *)
+let host, port = Unix.inet_addr_loopback, 8080
+
+let listening_sock () =
+  let addr = Unix.(ADDR_INET (host, port)) in
+  let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.bind sock addr;
+  Unix.listen sock 10;
+  let sock_accept = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt sock SO_REUSEADDR true;
+  (* Unix.setsockopt sock SO_REUSEPORT true; *)
+  Iocp.Handle.of_unix sock, Iocp.Handle.of_unix sock_accept
+
+let print_sockaddr = function
+  | Unix.ADDR_UNIX s -> print_endline ("UNIX:" ^ s)
+  | ADDR_INET (host, port) -> print_endline ("INET:" ^ Unix.string_of_inet_addr host ^ ":" ^ string_of_int port)
+
+type req = [ `A | `R ]
+
+let () =
+  let iocp = Iocp.create () in
+  let sock, sock_accept = listening_sock () in
+  let addr_buf = Iocp.Accept_buffer.create () in
+  let _job = Iocp.accept iocp sock sock_accept addr_buf `A (Iocp.Overlapped.create ()) in
+  match Iocp.get_queued_completion_status iocp with
+  | None -> assert false
+  | Some t ->
+    assert (t.data = `A);
+    let sockaddr = Iocp.Accept_buffer.get_remote addr_buf sock in
+    let unix = Iocp.Sockaddr.get sockaddr in
+    print_sockaddr unix;
+    let buf = Cstruct.create 1024 in
+    let _job = Iocp.read_file iocp sock_accept buf 1024 `R (Iocp.Overlapped.create ()) in
+    match Iocp.get_queued_completion_status iocp with
+    | None -> assert false
+    | Some t ->
+      assert (t.data = `R);
+      print_endline (Cstruct.to_string buf)


### PR DESCRIPTION
This PR adds asynchronous network connections using [AcceptEx](https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-acceptex).

It is a little different to other APIs in that you must pass it two sockets. One socket is the conventional listening socket which dictates what address we're waiting for connections on, the second socket is the one that actually does the accepting:

> sAcceptSocket
> A descriptor identifying a socket on which to accept an incoming connection. This socket must not be bound or connected.

Whereas, [`accept(2)`](https://man7.org/linux/man-pages/man2/accept.2.html) creates a socket internally for you, this API does not and you must provide it. I believe this can be used as an optimisation where socket creation is not necessarily cheap and instead of doing in when a new connection is accepted, you could have a pool of sockets ready to go in advance and take the upfront hit of creating them in a more controlled way.