### PR TITLE
Distinguish file offset and buffer offset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: Windows CI
 on:
-  pull_request: [ main ]
-  push: [ main ]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Windows CI
 on:
-  pull_request:
-  push:
+  pull_request: [ main ]
+  push: [ main ]
 jobs:
   build:
     strategy:

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ let () =
   let fd = Iocp.Handle.openfile Sys.argv.(1) [O_RDONLY] 0 in
   let out = Iocp.Handle.openfile Sys.argv.(2) [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
   let buf = Cstruct.create 1024 in
-  let _job = Iocp.read_fixed iocp fd buf ~off:0 ~len:1024 `R in
+  let _job = Iocp.read iocp ~file_offset:Optint.Int63.zero fd buf ~off:0 ~len:1024 `R in
   match Iocp.get_queued_completion_status iocp with
     | None -> assert false
     | Some t ->
       assert (t.data = `R);
-      let _job = Iocp.write_fixed iocp out buf ~off:0 ~len:t.bytes_transferred `W in
+      let _job = Iocp.write iocp ~file_offset:Optint.Int63.zero out buf ~off:0 ~len:t.bytes_transferred `W in
       match Iocp.get_queued_completion_status iocp with
       | None -> assert false
       | Some t ->

--- a/dune-project
+++ b/dune-project
@@ -12,5 +12,6 @@
  (description "Bindings to the Windows IOCP API. See https://github.com/ocaml-multicore/eio for a higher-level API using this.")
  (depends
    cstruct
+   optint
    (mdx :with-test)))
 (using mdx 0.1)

--- a/iocp.opam
+++ b/iocp.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/patricoferris/ocaml-iocp/issues"
 depends: [
   "dune" {>= "2.9"}
   "cstruct"
+  "optint"
   "mdx" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name iocp)
  (public_name iocp)
- (libraries unix cstruct)
+ (libraries unix cstruct optint)
  (foreign_stubs
    (language c)
    (names iocp_stubs)))

--- a/src/iocp.mli
+++ b/src/iocp.mli
@@ -3,11 +3,13 @@
     Bindings to input/output completion ports (IOCP) allowing for efficient,
     asynchronous IO on Windows. *)
 
+type offset := Optint.Int63.t
+
 module Overlapped : sig
   type t
   (** An overlapped structure used for asynchronous IO. *)
 
-  val create : ?off:int -> unit -> t
+  val create : ?off:offset -> unit -> t
   (** An overlapped structure where the offset can be set (defaults to 0). *)
 end
 
@@ -58,14 +60,14 @@ val get_queued_completion_status : 'a t  -> 'a completion_status option
 (** [get_queued_completion_status t] will wait indefinitely for a completion packet to arrive 
     at the completion port [t]. *)
 
-val read_fixed : 'a t -> Handle.t -> Cstruct.t -> off:int -> len:int -> 'a -> 'a job option
-(** [read_fixed t fd buf off len d] reads [len] bytes of data from [fd] at a given offset [off]
-    using [t] as the completion port for the read request. [d] is the user associated data for 
-    the request. *)
+val read : 'a t -> file_offset:offset -> Handle.t -> Cstruct.t -> off:int -> len:int -> 'a -> 'a job option
+(** [read t ~file_offset fd buf ~off ~len d] reads [len] bytes of data from [fd] at a given absolute 
+    offset [file_offset] using [t] as the completion port for the read request. The data is read into [buf] at offset [off].
+    [d] is the user associated data for the request. *)
 
-val write_fixed  : 'a t -> Handle.t -> Cstruct.t -> off:int -> len:int -> 'a -> 'a job option
-(** [write_fixed t fd buf off len d] writes [len] bytes of data to [fd] at a given offset [off]
-    using [t] as the completion port for the write request. [d] is the user associated data for 
+val write  : 'a t -> file_offset:offset -> Handle.t -> Cstruct.t -> off:int -> len:int -> 'a -> 'a job option
+(** [write t ~file_offset fd buf ~off ~len d] writes [len] bytes of data to [fd] at a given absolute offset [file_offset]
+    using [t] as the completion port for the write request. Data is read from [buf] at offset [off]. [d] is the user associated data for 
     the request. *)
 
 (** {2 Networking} *)

--- a/src/iocp_stubs.c
+++ b/src/iocp_stubs.c
@@ -181,13 +181,14 @@ value ocaml_iocp_get_queued_completion_status(value v_fd) {
     CAMLreturn(v);
 }
 
-value ocaml_iocp_read_fixed(value v_cp, value v_fd, value v_id, value v_ba, value v_num_bytes, value v_overlapped) {
+value ocaml_iocp_read(value v_cp, value v_fd, value v_id, value v_ba, value v_num_bytes, value v_off, value v_overlapped) {
     CAMLparam4(v_cp, v_fd, v_ba, v_overlapped);
     LPOVERLAPPED ol = Overlapped_val(v_overlapped);
 
     // Here we associate the file handle to the completion port handle...
+    void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
     HANDLE _cp = CreateIoCompletionPort(Handle_val(v_fd), Handle_val(v_cp), Long_val(v_id), 0);
-    BOOL b = ReadFile(Handle_val(v_fd), Caml_ba_data_val(v_ba), Int_val(v_num_bytes), NULL, ol);
+    BOOL b = ReadFile(Handle_val(v_fd), buf, Int_val(v_num_bytes), NULL, ol);
 
     // The return value is non-zero (TRUE) on success. However, it is FALSE if the IO operation
     // is completing asynchronously. We change that behaviour by checking last error.
@@ -197,17 +198,18 @@ value ocaml_iocp_read_fixed(value v_cp, value v_fd, value v_id, value v_ba, valu
     CAMLreturn(Val_bool(b));
 }
 
-value ocaml_iocp_read_fixed_bytes(value* values, int argc) {
-    return ocaml_iocp_read_fixed(values[0], values[1], values[2], values[3], values[4], values[5]);
+value ocaml_iocp_read_bytes(value* values, int argc) {
+    return ocaml_iocp_read(values[0], values[1], values[2], values[3], values[4], values[5], values[6]);
 }
 
-value ocaml_iocp_write_fixed(value v_cp, value v_fd, value v_id, value v_ba, value v_num_bytes, value v_overlapped) {
+value ocaml_iocp_write(value v_cp, value v_fd, value v_id, value v_ba, value v_num_bytes, value v_off, value v_overlapped) {
     CAMLparam4(v_cp, v_fd, v_ba, v_overlapped);
     LPOVERLAPPED ol = Overlapped_val(v_overlapped);
 
     // Here we associate the file handle to the completion port handle...
+    void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
     HANDLE _cp = CreateIoCompletionPort(Handle_val(v_fd), Handle_val(v_cp), Long_val(v_id), 0);
-    BOOL b = WriteFile(Handle_val(v_fd), Caml_ba_data_val(v_ba), Int_val(v_num_bytes), NULL, ol);
+    BOOL b = WriteFile(Handle_val(v_fd), buf, Int_val(v_num_bytes), NULL, ol);
 
     // The return value is non-zero (TRUE) on success. However, it is FALSE if the IO operation
     // is completing asynchronously. We change that behaviour by checking last error.
@@ -217,8 +219,8 @@ value ocaml_iocp_write_fixed(value v_cp, value v_fd, value v_id, value v_ba, val
     CAMLreturn(Val_bool(b));
 }
 
-value ocaml_iocp_write_fixed_bytes(value* values, int argc) {
-    return ocaml_iocp_write_fixed(values[0], values[1], values[2], values[3], values[4], values[5]);
+value ocaml_iocp_write_bytes(value* values, int argc) {
+    return ocaml_iocp_write(values[0], values[1], values[2], values[3], values[4], values[5], values[6]);
 }
 
 GUID GuidGetAddrAcceptEx = WSAID_GETACCEPTEXSOCKADDRS;

--- a/test/copy.ml
+++ b/test/copy.ml
@@ -5,12 +5,12 @@ let () =
   let fd = Iocp.Handle.openfile Sys.argv.(1) [O_RDONLY] 0 in
   let out = Iocp.Handle.openfile Sys.argv.(2) [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
   let buf = Cstruct.create 1024 in
-  let _job = Iocp.read_fixed iocp fd buf ~off:0 ~len:1024 `R in
+  let _job = Iocp.read iocp ~file_offset:Optint.Int63.zero fd buf ~off:0 ~len:1024 `R in
   match Iocp.get_queued_completion_status iocp with
     | None -> assert false
     | Some t ->
       assert (t.data = `R);
-      let _job = Iocp.write_fixed iocp out buf ~off:0 ~len:t.bytes_transferred `W in
+      let _job = Iocp.write iocp ~file_offset:Optint.Int63.zero out buf ~off:0 ~len:t.bytes_transferred `W in
       match Iocp.get_queued_completion_status iocp with
       | None -> assert false
       | Some t ->

--- a/test/net.ml
+++ b/test/net.ml
@@ -30,7 +30,7 @@ let () =
     let unix = Iocp.Sockaddr.get sockaddr in
     print_sockaddr unix;
     let buf = Cstruct.create 1024 in
-    let _job = Iocp.read iocp ~file_offset:0 sock_accept buf ~off:0 ~len:1024 `R in
+    let _job = Iocp.read iocp ~file_offset:Optint.Int63.zero sock_accept buf ~off:0 ~len:1024 `R in
     match Iocp.get_queued_completion_status iocp with
     | None -> assert false
     | Some t ->

--- a/test/net.ml
+++ b/test/net.ml
@@ -30,7 +30,7 @@ let () =
     let unix = Iocp.Sockaddr.get sockaddr in
     print_sockaddr unix;
     let buf = Cstruct.create 1024 in
-    let _job = Iocp.read_fixed iocp sock_accept buf ~off:0 ~len:1024 `R in
+    let _job = Iocp.read iocp ~file_offset:0 sock_accept buf ~off:0 ~len:1024 `R in
     match Iocp.get_queued_completion_status iocp with
     | None -> assert false
     | Some t ->


### PR DESCRIPTION
Tidies the read and write some more and allows the user to specify both the file offset to read from or write to, as well as the buffer offset to read into or write from as a source. Again, this is the same idea as the read/write functions in ocaml-uring. 